### PR TITLE
Include string header

### DIFF
--- a/src/safecast.h
+++ b/src/safecast.h
@@ -14,6 +14,7 @@
 #ifndef SAFECAST_H
 #define SAFECAST_H
 
+#include <string>
 #include <cstdint>
 #include <exception>
 #include <limits>


### PR DESCRIPTION
Currency the header doesn't `#include <string>` despite it using `std::string`. This makes it unusable unless `<string>` is previously included in a consuming source file. The other headers might include string, although this will be an implementation detail.